### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/todolist-web-servlet-jsp/src/main/java/io/github/benas/todolist/web/util/Views.java
+++ b/todolist-web-servlet-jsp/src/main/java/io/github/benas/todolist/web/util/Views.java
@@ -6,6 +6,8 @@ package io.github.benas.todolist.web.util;
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
 public class Views {
+    
+    private Views() {}
 
     public static final String PREFIX = "/WEB-INF/views";
 

--- a/todolist-web-tapestry/src/main/java/io/github/benas/todolist/web/services/TodoListModule.java
+++ b/todolist-web-tapestry/src/main/java/io/github/benas/todolist/web/services/TodoListModule.java
@@ -36,6 +36,9 @@ import org.got5.tapestry5.jquery.JQuerySymbolConstants;
  * @author Mahmoud Ben Hassine (mahmoud.benhassine@icloud.com)
  */
 public class TodoListModule {
+    
+    private TodoListModule() {}
+    
     public static void contributeFactoryDefaults(MappedConfiguration<String, Object> configuration) {
         configuration.override(SymbolConstants.APPLICATION_VERSION, "1.0-SNAPSHOT");
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed